### PR TITLE
Validate YAML file

### DIFF
--- a/deuqguv4.schema.yaml
+++ b/deuqguv4.schema.yaml
@@ -7,7 +7,7 @@ schema:
   version: "2017.1.12"
   author:
     - inzoi <13321873@qq.com>
-  description: 
+  description: |
     中古汉语QQ群：531376406
     2016.12.04
   dependencies:


### PR DESCRIPTION
Multi-line description without `|` is not a valid YAML.